### PR TITLE
Reintroduce JPackage

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -31,13 +31,34 @@ jobs:
             build/jpackage/*.pkg
             build/jpackage/*.exe
             build/jpackage/*.msi
+      - name: Upload jar
+        uses: actions/upload-artifact@v3
+        with:
+          name: fatjar
+          path: build/libs/kindling-bundle.jar
   create-release:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/download-artifact@v3
+      - name: Download Linux Artifacts
+        uses: actions/download-artifact@v3
         with:
+          name: ubuntu-latest
           path: artifacts
+      - name: Download MacOS Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: macos-latest
+          path: artifacts
+      - name: Download Windows Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: windows-latest
+          path: artifacts
+      - name: Download bundle jar
+        uses: actions/download-artifact@v3
+        with:
+          name: fatjar
       - name: Display structure of downloaded files
         run: ls -R
       - name: Create Release
@@ -47,6 +68,7 @@ jobs:
           prerelease: true
           files: |
             artifacts/*
+            kindling-bundle.jar
 #      - name: Setup Node
 #        uses: actions/setup-node@v2
 #        with:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -24,7 +24,13 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }}
-          path: build/jpackage/
+          path: |
+            build/jpackage/*.deb
+            build/jpackage/*.rpm
+            build/jpackage/*.dmg
+            build/jpackage/*.pkg
+            build/jpackage/*.exe
+            build/jpackage/*.msi
   create-release:
     runs-on: ubuntu-latest
     needs: [build]
@@ -34,13 +40,13 @@ jobs:
           path: artifacts
       - name: Display structure of downloaded files
         run: ls -R
-#      - name: Create Release
-#        uses: marvinpinto/action-automatic-releases@latest
-#        with:
-#          repo_token: ${{ secrets.GITHUB_TOKEN }}
-#          prerelease: false
-#          files: |
-#            artifacts/*
+      - name: Create Release
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          files: |
+            artifacts/*
 #      - name: Setup Node
 #        uses: actions/setup-node@v2
 #        with:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -58,7 +58,7 @@ jobs:
         uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: true
+          prerelease: false
           files: |
             artifacts/*
             kindling-bundle.jar

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -4,8 +4,11 @@ on:
     tags:
       - '*'
 jobs:
-  gradle:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
@@ -13,19 +16,42 @@ jobs:
           java-version: 17
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-      - name: Execute Gradle build & shadowJar
-        run: ./gradlew build shadowJar
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '17'
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
-      - name: Install JDeploy
-        run: npm install
-      - name: Set package version
-        run: npm --no-git-tag-version version ${{github.ref_name}}
-      - name: JDeploy Publish
-        run: npx jdeploy publish
+      - name: Execute Gradle build & JPackage
+        run: ./gradlew build jpackage
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TAG_VERSION: ${{github.ref_name}}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }}
+          path: build/jpackage/
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: Display structure of downloaded files
+        run: ls -R
+#      - name: Create Release
+#        uses: marvinpinto/action-automatic-releases@latest
+#        with:
+#          repo_token: ${{ secrets.GITHUB_TOKEN }}
+#          prerelease: false
+#          files: |
+#            artifacts/*
+#      - name: Setup Node
+#        uses: actions/setup-node@v2
+#        with:
+#          node-version: '17'
+#          registry-url: 'https://registry.npmjs.org'
+#          cache: 'npm'
+#      - name: Install JDeploy
+#        run: npm install
+#      - name: Set package version
+#        run: npm --no-git-tag-version version ${{github.ref_name}}
+#      - name: JDeploy Publish
+#        run: npx jdeploy publish
+#        env:
+#          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -27,8 +27,6 @@ jobs:
           path: |
             build/jpackage/*.deb
             build/jpackage/*.rpm
-            build/jpackage/*.dmg
-            build/jpackage/*.pkg
             build/jpackage/*.exe
             build/jpackage/*.msi
       - name: Upload jar
@@ -44,11 +42,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ubuntu-latest
-          path: artifacts
-      - name: Download MacOS Artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: macos-latest
           path: artifacts
       - name: Download Windows Artifacts
         uses: actions/download-artifact@v3
@@ -69,17 +62,17 @@ jobs:
           files: |
             artifacts/*
             kindling-bundle.jar
-#      - name: Setup Node
-#        uses: actions/setup-node@v2
-#        with:
-#          node-version: '17'
-#          registry-url: 'https://registry.npmjs.org'
-#          cache: 'npm'
-#      - name: Install JDeploy
-#        run: npm install
-#      - name: Set package version
-#        run: npm --no-git-tag-version version ${{github.ref_name}}
-#      - name: JDeploy Publish
-#        run: npx jdeploy publish
-#        env:
-#          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '17'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+      - name: Install JDeploy
+        run: npm install
+      - name: Set package version
+        run: npm --no-git-tag-version version ${{github.ref_name}}
+      - name: JDeploy Publish
+        run: npx jdeploy publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType.CHECKSTYLE
+import java.time.LocalDate
 
 @Suppress("DSL_SCOPE_VIOLATION") // https://youtrack.jetbrains.com/issue/KTIJ-19369
 plugins {
@@ -108,19 +109,14 @@ runtime {
 
     jpackage {
         val currentOs = OperatingSystem.current()
-        val imgType = when {
-            currentOs.isWindows -> "ico"
-            currentOs.isMacOsX -> "icns"
-            else -> "png"
-        }
-        // Reverse the package version because MacOS doesn't like leading zeroes
+        val imgType = if (currentOs.isWindows) "ico" else "png"
         appVersion = System.getenv("TAG_VERSION") ?: "1.0.0"
         imageOptions = listOf("--icon", "src/main/resources/icons/ignition.$imgType")
         @OptIn(ExperimentalStdlibApi::class)
         val options: Map<String, String?> = buildMap {
             put("resource-dir", "src/main/resources")
             put("vendor", "Paul Griffith")
-            put("copyright", "2022")
+            put("copyright", LocalDate.now().year.toString())
             put("description", "A collection of useful tools for troubleshooting Ignition")
 
             when {
@@ -132,7 +128,6 @@ runtime {
                     // random (consistent) UUID makes upgrades smoother
                     put("win-upgrade-uuid", "8e7428c8-bbc6-460a-9995-db6d8b04a690")
                 }
-
                 currentOs.isLinux -> {
                     put("linux-shortcut", null)
                 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType.CHECKSTYLE
 
@@ -9,6 +10,7 @@ plugins {
     alias(libs.plugins.serialization)
     alias(libs.plugins.ktlint)
     alias(libs.plugins.shadow)
+    alias(libs.plugins.runtime)
 }
 
 group = "io.github.paulgriffith"
@@ -86,8 +88,64 @@ java {
 }
 
 ktlint {
-    disabledRules.add("trailing-comma-on-call-site")
     reporters {
         reporter(CHECKSTYLE)
+    }
+}
+
+runtime {
+    options.set(listOf("--strip-debug", "--compress", "2", "--no-header-files", "--no-man-pages"))
+
+    modules.set(
+        listOf(
+            "java.desktop",
+            "java.sql",
+            "java.logging",
+            "java.naming",
+            "java.xml"
+        )
+    )
+
+    jpackage {
+        val currentOs = OperatingSystem.current()
+        val imgType = when {
+            currentOs.isWindows -> "ico"
+            currentOs.isMacOsX -> "icns"
+            else -> "png"
+        }
+        // Reverse the package version because MacOS doesn't like leading zeroes
+        appVersion = System.getenv("TAG_VERSION") ?: "1.0.0"
+        imageOptions = listOf("--icon", "src/main/resources/icons/ignition.$imgType")
+        @OptIn(ExperimentalStdlibApi::class)
+        val options: Map<String, String?> = buildMap {
+            put("resource-dir", "src/main/resources")
+            put("vendor", "Paul Griffith")
+            put("copyright", "2022")
+            put("description", "A collection of useful tools for troubleshooting Ignition")
+
+            when {
+                currentOs.isWindows -> {
+                    put("win-per-user-install", null)
+                    put("win-dir-chooser", null)
+                    put("win-menu", null)
+                    put("win-shortcut", null)
+                    // random (consistent) UUID makes upgrades smoother
+                    put("win-upgrade-uuid", "8e7428c8-bbc6-460a-9995-db6d8b04a690")
+                }
+
+                currentOs.isLinux -> {
+                    put("linux-shortcut", null)
+                }
+            }
+        }
+
+        // add-exports is used to bypass Java modular restrictions
+        jvmArgs = listOf("--add-exports", "java.desktop/com.sun.java.swing.plaf.windows=ALL-UNNAMED")
+
+        installerOptions = options.flatMap { (key, value) ->
+            listOfNotNull("--$key", value)
+        }
+
+        mainJar = "kindling-bundle.jar"
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "10.3.0" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
+runtime = { id = "org.beryx.runtime", version = "1.12.7" }
 
 [libraries]
 # core functionality


### PR DESCRIPTION
Skipping MacOS builds for now, because code signing, but Windows and Linux artifacts appear to work. MacOS will also require a 'soft' version bump to something higher than 1.0.0, but that can all wait.