### PR TITLE
Escape HTML in details pane

### DIFF
--- a/core/src/main/kotlin/io/github/paulgriffith/kindling/core/DetailsPane.kt
+++ b/core/src/main/kotlin/io/github/paulgriffith/kindling/core/DetailsPane.kt
@@ -5,6 +5,7 @@ import com.formdev.flatlaf.extras.components.FlatTextPane
 import io.github.paulgriffith.kindling.internal.DetailsIcon
 import io.github.paulgriffith.kindling.utils.Action
 import io.github.paulgriffith.kindling.utils.FlatScrollPane
+import io.github.paulgriffith.kindling.utils.escapeHtml
 import net.miginfocom.swing.MigLayout
 import java.awt.Component
 import java.awt.EventQueue
@@ -79,10 +80,10 @@ class DetailsPane : JPanel(MigLayout("ins 0, fill")) {
                 append("</b>")
                 if (event.message != null) {
                     append("<br>")
-                    append(event.message)
+                    append(event.message.escapeHtml())
                 }
                 if (event.body.isNotEmpty()) {
-                    event.body.joinTo(buffer = this, separator = "\n", prefix = "<pre>", postfix = "</pre>")
+                    event.body.joinTo(buffer = this, separator = "\n", prefix = "<pre>", postfix = "</pre>", transform = String::escapeHtml)
                 } else {
                     append("<br>")
                 }

--- a/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/utils.kt
+++ b/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/utils.kt
@@ -146,3 +146,15 @@ fun TableModel.exportToXLSX(file: File) = file.outputStream().use { fos ->
 inline fun <reified S> loadService(): ServiceLoader<S> {
     return ServiceLoader.load(S::class.java)
 }
+
+fun String.escapeHtml(): String {
+    return buildString {
+        for (char in this@escapeHtml) {
+            when (char) {
+                '>' -> append("&gt;")
+                '<' -> append("&lt;")
+                else -> append(char)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Came up in a cache dump from a support rep.

As a related task, should investigate support for `com.inductiveautomation.factorysql.groups.storedprocgroup.SPHistoricalData`. I tried for a little while to get this class to show up, but the instance from the customer had Jython objects serialized within, which would significantly bloat the download size, which I'd like to avoid. Not sure the best path forward.
