### PR TITLE
Threadview fixes

### DIFF
--- a/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/swing.kt
+++ b/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/swing.kt
@@ -276,11 +276,13 @@ class ReifiedJXTable<T : TableModel>(
             require(model::class.java == modelClass) { "Expected $modelClass but got ${model::class.java}" }
         }
         val sortedColumn = sortedColumnIndex
+        val sortedColumnIsVisible = convertColumnIndexToView(sortedColumn) != -1
+
         val sortOrder = if (sortedColumn >= 0) (rowSorter as SortController<*>).getSortOrder(sortedColumn) else null
 
         super.setModel(model)
 
-        if (sortOrder != null) {
+        if (sortOrder != null && sortedColumnIsVisible) {
             setSortOrder(sortedColumn, sortOrder)
         }
         if (setup) {

--- a/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/utils.kt
+++ b/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/utils.kt
@@ -51,10 +51,13 @@ inline fun StringBuilder.tag(tag: String, content: StringBuilder.() -> Unit) {
 }
 
 fun StringBuilder.tag(tag: String, content: String) {
-    append("<").append(tag).append(">")
-    append(content)
-    append("</").append(tag).append(">")
+    tag(tag) { append( content) }
 }
+
+/**
+ * Returns the mode (most common value) in a Grouping<T>
+ */
+fun <T> Grouping<T, Int>.mode(): Int? = eachCount().maxOfOrNull { it.key }
 
 val JDBCType.javaType: Class<*>
     get() = when (this) {

--- a/thread/src/main/kotlin/io/github/paulgriffith/kindling/thread/MultiThreadView.kt
+++ b/thread/src/main/kotlin/io/github/paulgriffith/kindling/thread/MultiThreadView.kt
@@ -4,7 +4,7 @@ import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.jidesoft.swing.CheckBoxListSelectionModel
 import io.github.paulgriffith.kindling.core.Detail
 import io.github.paulgriffith.kindling.core.Detail.BodyLine
-import io.github.paulgriffith.kindling.core.MultiTool
+import io.github.paulgriffith.kindling.core.MultiClipboardTool
 import io.github.paulgriffith.kindling.core.ToolOpeningException
 import io.github.paulgriffith.kindling.core.ToolPanel
 import io.github.paulgriffith.kindling.core.add
@@ -33,6 +33,7 @@ import org.jdesktop.swingx.decorator.ColorHighlighter
 import org.jdesktop.swingx.table.ColumnControlButton
 import java.awt.Desktop
 import java.awt.Rectangle
+import java.nio.file.Files
 import java.nio.file.Path
 import javax.swing.JLabel
 import javax.swing.JMenu
@@ -46,6 +47,7 @@ import javax.swing.UIManager
 import kotlin.io.path.inputStream
 import kotlin.io.path.name
 import kotlin.io.path.nameWithoutExtension
+import kotlin.io.path.outputStream
 
 class MultiThreadView(
     private val paths: List<Path>,
@@ -444,7 +446,7 @@ class MultiThreadView(
     }
 }
 
-object MultiThreadViewer : MultiTool {
+object MultiThreadViewer : MultiClipboardTool {
     override val title = "Thread Viewer"
     override val description = "Thread dump (.json or .txt) files"
     override val icon = FlatSVGIcon("icons/bx-file.svg")
@@ -453,7 +455,13 @@ object MultiThreadViewer : MultiTool {
     override fun open(paths: List<Path>): ToolPanel {
         return MultiThreadView(paths.sorted())
     }
-    //TODO: Implement Clipboard tool
+    override fun open(data: String): ToolPanel {
+        val tempFile = Files.createTempFile("kindling", "cb")
+        data.byteInputStream().use { threadDump ->
+            tempFile.outputStream().use(threadDump::copyTo)
+        }
+        return open(tempFile)
+    }
 }
 
-class ThreadViewerProxy : MultiTool by MultiThreadViewer
+class ThreadViewerProxy : MultiClipboardTool by MultiThreadViewer

--- a/thread/src/main/kotlin/io/github/paulgriffith/kindling/thread/MultiThreadView.kt
+++ b/thread/src/main/kotlin/io/github/paulgriffith/kindling/thread/MultiThreadView.kt
@@ -189,13 +189,18 @@ class MultiThreadView(
     private val threadDumpCheckboxList = ThreadDumpCheckboxList(paths).apply {
         isVisible = !mainTable.model.isSingleContext
     }
+
     private var listModelsAdjusting = false
 
-    private val exportButton = JMenuBar().apply {
+    private val exportMenu = run {
         val firstThreadDump = threadDumps.first()
         val fileName = "threaddump_${firstThreadDump.version}_${firstThreadDump.hashCode()}"
-        add(exportMenu(fileName) { mainTable.model })
-        isVisible = mainTable.model.isSingleContext
+        exportMenu(fileName) { mainTable.model }
+    }
+
+    private val exportButton = JMenuBar().apply {
+        add(exportMenu)
+        exportMenu.isEnabled = mainTable.model.isSingleContext
     }
 
     private fun filter(thread: Thread?): Boolean {
@@ -238,7 +243,7 @@ class MultiThreadView(
                 mainTable.columnFactory = newModel.columns.toColumnFactory()
                 mainTable.model = newModel
                 mainTable.createDefaultColumnsFromModel()
-                exportButton.isVisible = newModel.isSingleContext
+                exportMenu.isEnabled = newModel.isSingleContext
 
                 if (selectedID != null) {
                     val newSelectedIndex = mainTable.model.threadData.indexOfFirst { lifespan ->
@@ -281,7 +286,7 @@ class MultiThreadView(
                 if (!event.valueIsAdjusting) {
                     listModelsAdjusting = true
 
-                    val selectedThreadDumps =List(threadDumps.size) { i ->
+                    val selectedThreadDumps = List(threadDumps.size) { i ->
                         if (isSelectedIndex(i + 1)) {
                             threadDumps[i]
                         } else {

--- a/thread/src/main/kotlin/io/github/paulgriffith/kindling/thread/model/ThreadModel.kt
+++ b/thread/src/main/kotlin/io/github/paulgriffith/kindling/thread/model/ThreadModel.kt
@@ -14,7 +14,7 @@ import java.lang.Thread.State.NEW
 import java.lang.Thread.State.RUNNABLE
 import java.lang.Thread.State.TIMED_WAITING
 import java.lang.Thread.State.WAITING
-import java.text.NumberFormat
+import java.text.DecimalFormat
 import javax.swing.table.AbstractTableModel
 import java.lang.Thread.State as ThreadState
 
@@ -22,7 +22,7 @@ import java.lang.Thread.State as ThreadState
 typealias ThreadLifespan = List<Thread?>
 
 sealed class ThreadColumnList : ColumnList<ThreadLifespan>() {
-    private val percent: NumberFormat = NumberFormat.getPercentInstance()
+    private val percent = DecimalFormat("0.000'%'")
 
     val mark = Column<ThreadLifespan, Boolean>(
         header = "Mark",
@@ -59,7 +59,7 @@ sealed class ThreadColumnList : ColumnList<ThreadLifespan>() {
         header = "CPU",
         columnCustomization = {
             cellRenderer = DefaultTableRenderer { value ->
-                (value as? Double)?.let { percent.format(it / 100) }.orEmpty()
+                (value as? Double)?.let { percent.format(it) }.orEmpty()
             }
         },
         getValue = { threads ->


### PR DESCRIPTION
- Add highlighting to comparison pane for max cpu usage and largest stack trace.
- Reintroduce clipboard tool compatibility. (Only one Thread Dump can be pasted)
- Small little bypass for an error that occurs when sorting by a column which is invisible by default and the model changes. We simply check to make sure the column is visible before attempting to sort by it now. 
- CPU usage was showing 0.0% for values that were small. I believe this issue was related to the number foratter used. Changed to a generic decimal formatter and increased precision for more accurate values.