### PR TITLE
Cache improvements

### DIFF
--- a/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheEntry.kt
+++ b/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheEntry.kt
@@ -6,5 +6,5 @@ data class CacheEntry(
     val schemaName: String,
     val timestamp: String,
     val attemptCount: Int,
-    val dataCount: Int
+    val dataCount: Int,
 )

--- a/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheEntry.kt
+++ b/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheEntry.kt
@@ -3,6 +3,7 @@ package io.github.paulgriffith.kindling.cache
 data class CacheEntry(
     val id: Int,
     val schemaId: Int,
+    val schemaName: String,
     val timestamp: String,
     val attemptCount: Int,
     val dataCount: Int

--- a/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheModel.kt
+++ b/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheModel.kt
@@ -27,6 +27,7 @@ class CacheModel(private val entries: List<CacheEntry>) : AbstractTableModel() {
             value = CacheEntry::id
         )
         val SchemaId by column { it.schemaId }
+        val SchemaName by column { it.schemaName }
         val Timestamp by column { it.timestamp }
         val AttemptCount by column(name = "Attempt Count") { it.attemptCount }
         val DataCount by column(name = "Data Count") { it.dataCount }

--- a/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheModel.kt
+++ b/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheModel.kt
@@ -5,7 +5,7 @@ import io.github.paulgriffith.kindling.utils.ColumnList
 import org.jdesktop.swingx.renderer.DefaultTableRenderer
 import javax.swing.table.AbstractTableModel
 
-class CacheModel(val entries: List<CacheEntry>) : AbstractTableModel() {
+class CacheModel(private val entries: List<CacheEntry>) : AbstractTableModel() {
     override fun getColumnName(column: Int): String = CacheColumns[column].header
     override fun getRowCount(): Int = entries.size
     override fun getColumnCount(): Int = size
@@ -24,7 +24,7 @@ class CacheModel(val entries: List<CacheEntry>) : AbstractTableModel() {
             column = {
                 cellRenderer = DefaultTableRenderer(Any?::toString)
             },
-            value = CacheEntry::id
+            value = CacheEntry::id,
         )
         val SchemaId by column { it.schemaId }
         val Timestamp by column { it.timestamp }
@@ -34,7 +34,7 @@ class CacheModel(val entries: List<CacheEntry>) : AbstractTableModel() {
             column = {
                 isVisible = false
             },
-            value = CacheEntry::schemaName
+            value = CacheEntry::schemaName,
         )
     }
 }

--- a/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheModel.kt
+++ b/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheModel.kt
@@ -5,7 +5,7 @@ import io.github.paulgriffith.kindling.utils.ColumnList
 import org.jdesktop.swingx.renderer.DefaultTableRenderer
 import javax.swing.table.AbstractTableModel
 
-class CacheModel(private val entries: List<CacheEntry>) : AbstractTableModel() {
+class CacheModel(val entries: List<CacheEntry>) : AbstractTableModel() {
     override fun getColumnName(column: Int): String = CacheColumns[column].header
     override fun getRowCount(): Int = entries.size
     override fun getColumnCount(): Int = size
@@ -27,9 +27,14 @@ class CacheModel(private val entries: List<CacheEntry>) : AbstractTableModel() {
             value = CacheEntry::id
         )
         val SchemaId by column { it.schemaId }
-        val SchemaName by column { it.schemaName }
         val Timestamp by column { it.timestamp }
         val AttemptCount by column(name = "Attempt Count") { it.attemptCount }
         val DataCount by column(name = "Data Count") { it.dataCount }
+        val SchemaName by column(
+            column = {
+                isVisible = false
+            },
+            value = CacheEntry::schemaName
+        )
     }
 }

--- a/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheView.kt
+++ b/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheView.kt
@@ -185,8 +185,8 @@ class CacheView(private val path: Path) : ToolPanel() {
 
     private fun SchemaRecord.toDetail(): Detail {
         return Detail(
-            title = name,
-            body = errors
+            title = "$name | ID = $id",
+            body = errors.ifEmpty { listOf("No errors associated with this schema.") }
         )
     }
 

--- a/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheView.kt
+++ b/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/CacheView.kt
@@ -169,6 +169,13 @@ class CacheView(private val path: Path) : ToolPanel() {
         return schemaRecords.find { it.id == entry.schemaId } in schemaList.checkBoxListSelectedValues
     }
 
+    private fun SchemaRecord.toDetail(): Detail {
+        return Detail(
+            title = name,
+            body = errors
+        )
+    }
+
     private val details = DetailsPane().apply {
         isExtraButtonsEnabled = false
     }
@@ -222,7 +229,12 @@ class CacheView(private val path: Path) : ToolPanel() {
     private val deserializedCache = mutableMapOf<Int, Detail>()
     private val model = CacheModel(data)
     private val table = ReifiedJXTable(model, CacheModel)
-    private val schemaList = SchemaFilterList(schemaRecords)
+    private val schemaList = SchemaFilterList(schemaRecords).apply {
+        selectionModel.addListSelectionListener {
+            details.events = selectedValuesList.filterIsInstance<SchemaRecord>().map { it.toDetail() }
+            details.isExtraButtonsEnabled = false
+        }
+    }
 
     private val settingsMenu = FlatPopupMenu().apply {
         add(
@@ -353,7 +365,7 @@ class CacheView(private val path: Path) : ToolPanel() {
 
         add(mainSplitPane, "push, grow, span")
 
-        details.addSideButton(arrayToTableButton)
+        details.addButton(arrayToTableButton)
 
         table.selectionModel.addListSelectionListener { event ->
             if (!event.valueIsAdjusting) {

--- a/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/SchemaFilterList.kt
+++ b/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/SchemaFilterList.kt
@@ -1,0 +1,56 @@
+package io.github.paulgriffith.kindling.cache
+
+import com.jidesoft.swing.CheckBoxList
+import io.github.paulgriffith.kindling.utils.NoSelectionModel
+import io.github.paulgriffith.kindling.utils.escapeHtml
+import io.github.paulgriffith.kindling.utils.listCellRenderer
+import io.github.paulgriffith.kindling.utils.tag
+import javax.swing.AbstractListModel
+
+class SchemaModel(val data: Map<Int, String>) : AbstractListModel<Any>() {
+    private val comparator: Comparator<Map.Entry<Int, String>> = compareBy(nullsFirst()) { it.key }
+    private val values = data.entries.sortedWith(comparator)
+
+    override fun getSize(): Int {
+        return values.size + 1
+    }
+
+    override fun getElementAt(index: Int): Any {
+        return if (index == 0) {
+            CheckBoxList.ALL_ENTRY
+        } else {
+            values[index - 1].key
+        }
+    }
+
+    fun indexOf(value: Map.Entry<Int, String>): Int {
+        val indexOf = values.indexOf(value)
+        return if (indexOf >= 0) {
+            indexOf + 1
+        } else {
+            -1
+        }
+    }
+}
+
+class SchemaFilterList(modelData: Map<Int, String>) : CheckBoxList(SchemaModel(modelData)) {
+
+    init {
+        selectionModel = NoSelectionModel()
+        isClickInCheckBoxOnly = false
+
+        cellRenderer = listCellRenderer<Any?> { _, value, _, _, _ ->
+            text = when (value) {
+                is Int -> "ID: $value, Name: ${model.data[value]}"
+                else -> value.toString()
+            }
+        }
+    }
+
+    fun select(value: Map.Entry<Int, String>) {
+        val rowToSelect = model.indexOf(value)
+        checkBoxListSelectionModel.setSelectionInterval(rowToSelect, rowToSelect)
+    }
+
+    override fun getModel() = super.getModel() as SchemaModel
+}

--- a/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/SchemaRecord.kt
+++ b/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/SchemaRecord.kt
@@ -1,0 +1,7 @@
+package io.github.paulgriffith.kindling.cache
+
+data class SchemaRecord(
+    val id: Int,
+    val name: String,
+    val errors: List<String>
+)

--- a/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/SchemaRecord.kt
+++ b/cache/src/main/kotlin/io/github/paulgriffith/kindling/cache/SchemaRecord.kt
@@ -3,5 +3,5 @@ package io.github.paulgriffith.kindling.cache
 data class SchemaRecord(
     val id: Int,
     val name: String,
-    val errors: List<String>
+    val errors: List<String>,
 )

--- a/core/src/main/kotlin/io/github/paulgriffith/kindling/core/DetailsPane.kt
+++ b/core/src/main/kotlin/io/github/paulgriffith/kindling/core/DetailsPane.kt
@@ -14,6 +14,7 @@ import java.awt.Rectangle
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
 import javax.swing.JButton
+import javax.swing.JComponent
 import javax.swing.JFileChooser
 import javax.swing.JPanel
 import javax.swing.event.HyperlinkEvent
@@ -28,6 +29,16 @@ import javax.swing.text.html.HTMLEditorKit
 import kotlin.properties.Delegates
 
 class DetailsPane : JPanel(MigLayout("ins 0, fill")) {
+
+    private val extraButtons = mutableListOf<JComponent>()
+    var isExtraButtonsEnabled: Boolean = true
+        set(value) {
+            field = value
+            extraButtons.onEach {
+                it.isEnabled = value
+            }
+        }
+
     var events: List<Detail> by Delegates.observable(emptyList()) { _, _, newValue ->
         textPane.text = newValue.toDisplayFormat()
         EventQueue.invokeLater {
@@ -72,6 +83,12 @@ class DetailsPane : JPanel(MigLayout("ins 0, fill")) {
         add(FlatScrollPane(textPane), "push, grow")
         add(JButton(copy), "cell 1 0, top, flowy, gap 0")
         add(JButton(save), "cell 1 0")
+    }
+
+    fun addSideButton(button: JButton) {
+        button.isEnabled = isExtraButtonsEnabled
+        add(button, "cell 1 0")
+        extraButtons.add(button)
     }
 
     private fun List<Detail>.toDisplayFormat(): String {

--- a/core/src/main/kotlin/io/github/paulgriffith/kindling/core/DetailsPane.kt
+++ b/core/src/main/kotlin/io/github/paulgriffith/kindling/core/DetailsPane.kt
@@ -13,8 +13,8 @@ import java.awt.EventQueue
 import java.awt.Rectangle
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
+import javax.swing.AbstractButton
 import javax.swing.JButton
-import javax.swing.JComponent
 import javax.swing.JFileChooser
 import javax.swing.JPanel
 import javax.swing.event.HyperlinkEvent
@@ -30,7 +30,7 @@ import kotlin.properties.Delegates
 
 class DetailsPane : JPanel(MigLayout("ins 0, fill")) {
 
-    private val extraButtons = mutableListOf<JComponent>()
+    private val extraButtons = mutableListOf<AbstractButton>()
     var isExtraButtonsEnabled: Boolean = true
         set(value) {
             field = value
@@ -85,7 +85,7 @@ class DetailsPane : JPanel(MigLayout("ins 0, fill")) {
         add(JButton(save), "cell 1 0")
     }
 
-    fun addSideButton(button: JButton) {
+    fun addButton(button: AbstractButton) {
         button.isEnabled = isExtraButtonsEnabled
         add(button, "cell 1 0")
         extraButtons.add(button)

--- a/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/TabStrip.kt
+++ b/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/TabStrip.kt
@@ -1,9 +1,7 @@
 package io.github.paulgriffith.kindling.utils
 
 import com.formdev.flatlaf.extras.components.FlatTabbedPane
-import io.github.paulgriffith.kindling.core.Kindling
-import java.awt.Component
-import java.awt.Dimension
+import java.awt.Container
 import javax.swing.Icon
 import javax.swing.JComponent
 import javax.swing.JFrame
@@ -94,12 +92,9 @@ class TabStrip : FlatTabbedPane() {
         }
     }
 
-    private fun <T> createPopupFrame(tab: T): JFrame where T : Component, T : FloatableComponent {
-        return JFrame(tab.name).apply {
-            preferredSize = Dimension(1024, 768)
-            iconImage = Kindling.frameIcon
-            defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
-            add(tab)
+    private fun <T> createPopupFrame(tab: T): JFrame where T : Container, T : FloatableComponent {
+        return jFrame(tab.name, 1024, 768) {
+            contentPane = tab
 
             jMenuBar = JMenuBar().apply {
                 add(
@@ -118,7 +113,6 @@ class TabStrip : FlatTabbedPane() {
                     },
                 )
             }
-            pack()
         }
     }
 }

--- a/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/swing.kt
+++ b/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/swing.kt
@@ -10,6 +10,7 @@ import com.formdev.flatlaf.themes.FlatMacDarkLaf
 import com.formdev.flatlaf.themes.FlatMacLightLaf
 import com.formdev.flatlaf.util.SystemInfo
 import com.jidesoft.swing.ListSearchable
+import io.github.paulgriffith.kindling.core.Kindling
 import io.github.paulgriffith.kindling.utils.ReifiedLabelProvider.Companion.setDefaultRenderer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -36,6 +37,7 @@ import javax.swing.DefaultListSelectionModel
 import javax.swing.Icon
 import javax.swing.JComponent
 import javax.swing.JFileChooser
+import javax.swing.JFrame
 import javax.swing.JLabel
 import javax.swing.JList
 import javax.swing.JPopupMenu
@@ -362,4 +364,21 @@ inline fun <reified T : EventListener> EventListenerList.add(listener: T) {
 
 inline fun <reified T : EventListener> EventListenerList.getAll(): Array<T> {
     return getListeners(T::class.java)
+}
+
+/**
+ * Constructs and immediately displays a JFrame of the given dimensions, centered on the screen.
+ */
+inline fun jFrame(title: String, width: Int, height: Int, block: JFrame.() -> Unit): JFrame {
+    return JFrame(title).apply {
+        setSize(width, height)
+        iconImage = Kindling.frameIcon
+        defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+
+        setLocationRelativeTo(null)
+
+        block()
+
+        isVisible = true
+    }
 }

--- a/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/utils.kt
+++ b/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/utils.kt
@@ -44,6 +44,16 @@ fun <T> ResultSet.toList(
     }
 }
 
+fun <T, R> ResultSet.toMap(keyColumn: String, valueColumn: String): Map<T, R> {
+    return use { rs ->
+        buildMap {
+            while (rs.next()) {
+                put(rs.getObject(keyColumn) as T, rs.getObject(valueColumn) as R)
+            }
+        }
+    }
+}
+
 inline fun StringBuilder.tag(tag: String, content: StringBuilder.() -> Unit) {
     append("<").append(tag).append(">")
     content(this)

--- a/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/utils.kt
+++ b/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/utils.kt
@@ -111,16 +111,6 @@ fun Long.toFileSizeLabel(): String = when {
     }
 }
 
-inline fun <reified T> transpose(xs: Array<Array<T>>): Array<Array<T>> {
-    val cols = xs[0].size
-    val rows = xs.size
-    return Array(cols) { j ->
-        Array(rows) { i ->
-            xs[i][j]
-        }
-    }
-}
-
 operator fun MatchGroupCollection.getValue(thisRef: Any?, property: KProperty<*>): MatchGroup {
     return requireNotNull(get(property.name))
 }

--- a/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/utils.kt
+++ b/core/src/main/kotlin/io/github/paulgriffith/kindling/utils/utils.kt
@@ -44,16 +44,6 @@ fun <T> ResultSet.toList(
     }
 }
 
-fun <T, R> ResultSet.toMap(keyColumn: String, valueColumn: String): Map<T, R> {
-    return use { rs ->
-        buildMap {
-            while (rs.next()) {
-                put(rs.getObject(keyColumn) as T, rs.getObject(valueColumn) as R)
-            }
-        }
-    }
-}
-
 inline fun StringBuilder.tag(tag: String, content: StringBuilder.() -> Unit) {
     append("<").append(tag).append(">")
     content(this)
@@ -118,6 +108,16 @@ fun Long.toFileSizeLabel(): String = when {
         val digits = log2(toDouble()).toInt() / 10
         val precision = digits.coerceIn(0, 2)
         "%,.${precision}f${prefix[digits]}b".format(toDouble() / 2.0.pow(digits * 10.0))
+    }
+}
+
+inline fun <reified T> transpose(xs: Array<Array<T>>): Array<Array<T>> {
+    val cols = xs[0].size
+    val rows = xs.size
+    return Array(cols) { j ->
+        Array(rows) { i ->
+            xs[i][j]
+        }
     }
 }
 

--- a/thread/src/main/kotlin/io/github/paulgriffith/kindling/thread/ThreadComparisonPane.kt
+++ b/thread/src/main/kotlin/io/github/paulgriffith/kindling/thread/ThreadComparisonPane.kt
@@ -16,6 +16,7 @@ import io.github.paulgriffith.kindling.utils.ScrollingTextPane
 import io.github.paulgriffith.kindling.utils.add
 import io.github.paulgriffith.kindling.utils.escapeHtml
 import io.github.paulgriffith.kindling.utils.getAll
+import io.github.paulgriffith.kindling.utils.jFrame
 import io.github.paulgriffith.kindling.utils.tag
 import net.miginfocom.swing.MigLayout
 import org.jdesktop.swingx.JXTaskPane
@@ -26,7 +27,6 @@ import java.awt.event.MouseEvent
 import java.text.NumberFormat
 import java.util.EventListener
 import javax.swing.JCheckBoxMenuItem
-import javax.swing.JFrame
 import javax.swing.JPanel
 import javax.swing.event.EventListenerList
 import javax.swing.event.HyperlinkEvent
@@ -119,7 +119,7 @@ class ThreadComparisonPane(
                 object { 
                     padding-left: 16px; 
                 }
-                """.trimIndent(),
+                    """.trimIndent(),
                 )
             }
         }
@@ -254,16 +254,8 @@ class ThreadComparisonPane(
             toolTipText = "Open in details popup"
             addActionListener {
                 thread?.let {
-                    JFrame("Thread ${it.id} Details").apply {
-                        setSize(900, 500)
-                        isResizable = true
-                        setLocationRelativeTo(null)
-                        add(
-                            DetailsPane().apply {
-                                events = listOf(it.toDetail(version))
-                            },
-                        )
-                        isVisible = true
+                    jFrame("Thread ${it.id} Details", 900, 500) {
+                        contentPane = DetailsPane(listOf(it.toDetail(version)))
                     }
                 }
             }

--- a/zip/src/main/kotlin/io/github/paulgriffith/kindling/zip/views/TextFileView.kt
+++ b/zip/src/main/kotlin/io/github/paulgriffith/kindling/zip/views/TextFileView.kt
@@ -90,11 +90,17 @@ class TextFileView(override val provider: FileSystemProvider, override val path:
             "txt" to SYNTAX_STYLE_NONE,
             "md" to SYNTAX_STYLE_NONE,
             "p7b" to SYNTAX_STYLE_NONE,
+            "log" to SYNTAX_STYLE_NONE,
         )
 
         private val KNOWN_FILENAMES = setOf(
             "README",
             ".uuid",
+            "wrapper.log.1",
+            "wrapper.log.2",
+            "wrapper.log.3",
+            "wrapper.log.4",
+            "wrapper.log.5",
         )
 
         fun isTextFile(path: Path) = path.extension in KNOWN_EXTENSIONS || path.name in KNOWN_FILENAMES


### PR DESCRIPTION
- Add functionality to Details pane to add and remove new buttons, and enable/disable them by the button object or by a given string ID
- Added a new button to the details pane in the cache opener which shows transaction group data as a proper table view.
- Added a top banner with settings button and cache entry count
- Added new bottom pane which shows schema listed in the cache, along with their associated schema ID
- Schemata are clickable in the bottom pane to see any associated errors that have occured with that schema.
- Schema name is now a hidden column in the main table. Can be shown.
- Can filter by schema by clicking on the checkboxes in the bottom pane.

In a previous commit, the cache viewer was slightly modified to be able to open .data and .script files directly, without having to zip them up. This will work as long as all necessary files are in the same folder as the .data or .script file which is selected.