### PR TITLE
Initialized DetailsPane "textPane" with initial events value.

### DIFF
--- a/src/main/kotlin/io/github/paulgriffith/kindling/core/DetailsPane.kt
+++ b/src/main/kotlin/io/github/paulgriffith/kindling/core/DetailsPane.kt
@@ -88,6 +88,7 @@ class DetailsPane(initialEvents: List<Detail> = emptyList()) : JPanel(MigLayout(
     init {
         add(FlatScrollPane(textPane), "push, grow")
         add(actionPanel, "east")
+        textPane.text = events.toDisplayFormat()
     }
 
     private fun List<Detail>.toDisplayFormat(): String {


### PR DESCRIPTION
The delegates observer for DetailsPane event prop that sets the textPane's text does not trigger when the events prop is initialized, only upon value change. This means that to initialize a DetailsPane with initial events and have the textPane populated with the events, we need to either initialize events with an empty list and then change its value to initial events in the DetailsPane init function, or manually set the textPane text to the events content in the init function.