### PR TITLE
Fix comparator setter referencing old value.

### DIFF
--- a/src/main/kotlin/io/github/paulgriffith/kindling/thread/FilterList.kt
+++ b/src/main/kotlin/io/github/paulgriffith/kindling/thread/FilterList.kt
@@ -13,7 +13,7 @@ typealias FilterComparator = Comparator<Map.Entry<String?, Int>>
 class FilterModel(val rawData: Map<String?, Int>) : AbstractListModel<Any>() {
     var comparator: FilterComparator = byCountDesc
         set(value) {
-            values = rawData.entries.sortedWith(comparator).map { it.key }
+            values = rawData.entries.sortedWith(value).map { it.key }
             fireContentsChanged(this, 0, size)
             field = value
         }


### PR DESCRIPTION
Comparator setter was referencing itself instead of the new value, causing sorting to "delayed" by 1 click.