### PR TITLE
modified idb sql table timestamp column to align with idb log viewer

### DIFF
--- a/src/main/kotlin/io/github/paulgriffith/kindling/idb/generic/QueryResult.kt
+++ b/src/main/kotlin/io/github/paulgriffith/kindling/idb/generic/QueryResult.kt
@@ -1,5 +1,10 @@
 package io.github.paulgriffith.kindling.idb.generic
 
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import javax.swing.table.AbstractTableModel
 
 sealed interface QueryResult {
@@ -14,11 +19,33 @@ sealed interface QueryResult {
             require(columnNames.size == columnTypes.size)
         }
 
+        private val dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss:SSS")
+
         override fun getRowCount(): Int = data.size
         override fun getColumnCount(): Int = columnNames.size
         override fun getColumnName(columnIndex: Int): String = columnNames[columnIndex]
         override fun getColumnClass(columnIndex: Int): Class<*> = columnTypes[columnIndex]
-        override fun getValueAt(rowIndex: Int, columnIndex: Int): Any? = data[rowIndex][columnIndex]
+        override fun getValueAt(rowIndex: Int, columnIndex: Int): Any? {
+            val originalValue = data[rowIndex][columnIndex]
+            val columnType = columnTypes[columnIndex]
+            return when {
+                originalValue is Timestamp -> {
+                    dateTimeFormatter.format(
+                        originalValue.toInstant()
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalDateTime()
+                    )
+                }
+                columnType == Timestamp::class.java && originalValue is Long -> {
+                    dateTimeFormatter.format(
+                        Instant.ofEpochMilli(originalValue)
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalDateTime()
+                    )
+                }
+                else -> originalValue
+            }
+        }
     }
 
     class Error(


### PR DESCRIPTION
Previously, when you use the idb sql query tool the "timestmp" column displayed as "Month day, year" This is a pretty useless format for a timestamp because you typically are looking for something more specific than the day. 

![image](https://github.com/user-attachments/assets/8adec8bd-723f-48e3-9d6c-08d2f2db14fa)

I modified this to instead display in the same format as the idb Logs viewer which uses a much better timestamp format.

![image](https://github.com/user-attachments/assets/4c628060-e630-4888-bfc7-c662477847c9)
